### PR TITLE
Utilize useLayoutEffect from rc-util

### DIFF
--- a/examples/fill-width.tsx
+++ b/examples/fill-width.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import useLayoutEffect from "rc-util/lib/hooks/useLayoutEffect";
 import Overflow from '../src';
 import '../assets/index.less';
 import './common.less';
@@ -63,7 +64,7 @@ const Demo = () => {
   const inputRef = React.useRef<HTMLInputElement>();
   const measureRef = React.useRef<HTMLDivElement>();
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     setInputWidth(measureRef.current.offsetWidth);
   }, [inputValue]);
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/runtime": "^7.11.1",
     "classnames": "^2.2.1",
     "rc-resize-observer": "^1.0.0",
-    "rc-util": "^5.5.1"
+    "rc-util": "^5.15.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.9",

--- a/src/Overflow.tsx
+++ b/src/Overflow.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useState, useMemo, useCallback } from 'react';
 import classNames from 'classnames';
 import ResizeObserver from 'rc-resize-observer';
+import useLayoutEffect from "rc-util/lib/hooks/useLayoutEffect";
 import Item from './Item';
 import { useBatchFrameState } from './hooks/useBatchFrameState';
 import RawItem from './RawItem';
@@ -215,7 +216,7 @@ function Overflow<ItemType = any>(
     return itemWidths.get(getKey(mergedData[index], index));
   }
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (mergedContainerWidth && mergedRestWidth && mergedData) {
       let totalWidth = suffixWidth;
 


### PR DESCRIPTION
Closes #6
Closes #18

This PR implements the [suggested fix ](https://github.com/react-component/overflow/pull/18#issuecomment-965923280) that is now available in `rc-util`. Please let me know if there is a better / different way to import the `useLayoutEffect` hook from `rc-util`