### PR TITLE
fix: secondary items not visible on IE11

### DIFF
--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -65,7 +65,7 @@ function InternalItem<ItemType>(
   if (!invalidate) {
     overflowStyle = {
       opacity: mergedHidden ? 0 : 1,
-      height: mergedHidden ? 0 : UNDEFINED,
+      // height: mergedHidden ? 0 : UNDEFINED,
       overflowY: mergedHidden ? 'hidden' : UNDEFINED,
       order: responsive ? order : UNDEFINED,
       pointerEvents: mergedHidden ? 'none' : UNDEFINED,


### PR DESCRIPTION
缘起于rc-menu的 https://github.com/react-component/menu/issues/444 ，
调试后发现，本repo的example-base，在IE11下，非第一个item不会展现出来。
参考 https://github.com/react-component/overflow/pull/2 ，得到最小化修正rc-menu的方法。

经本地测试，可解决 https://github.com/react-component/menu/issues/444

因对相关组理解不够深刻，关联影响未知。
