### PR TITLE
feat: add index to renderItem argument

### DIFF
--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -11,7 +11,7 @@ export interface ItemProps<ItemType> extends React.HTMLAttributes<any> {
   item?: ItemType;
   className?: string;
   style?: React.CSSProperties;
-  renderItem?: (item: ItemType) => React.ReactNode;
+  renderItem?: (item: ItemType, index: number) => React.ReactNode;
   responsive?: boolean;
   // https://github.com/ant-design/ant-design/issues/35475
   /**
@@ -66,7 +66,7 @@ function InternalItem<ItemType>(
 
   // ================================ Render ================================
   const childNode =
-    renderItem && item !== UNDEFINED ? renderItem(item) : children;
+    renderItem && item !== UNDEFINED ? renderItem(item, order) : children;
 
   let overflowStyle: React.CSSProperties | undefined;
   if (!invalidate) {

--- a/src/Overflow.tsx
+++ b/src/Overflow.tsx
@@ -41,7 +41,7 @@ export interface OverflowProps<ItemType> extends React.HTMLAttributes<any> {
   itemKey?: React.Key | ((item: ItemType) => React.Key);
   /** Used for `responsive`. It will limit render node to avoid perf issue */
   itemWidth?: number;
-  renderItem?: (item: ItemType) => React.ReactNode;
+  renderItem?: (item: ItemType, index: number) => React.ReactNode;
   /** @private Do not use in your production. Render raw node that need wrap Item by developer self */
   renderRawItem?: (item: ItemType, index: number) => React.ReactElement;
   maxCount?: number | typeof RESPONSIVE | typeof INVALIDATE;
@@ -172,7 +172,7 @@ function Overflow<ItemType = any>(
   );
 
   const mergedRenderItem = useCallback(
-    renderItem || ((item: ItemType) => item),
+    renderItem || ((item: ItemType, index: number) => item),
     [renderItem],
   );
 


### PR DESCRIPTION
When I need to add a separator between items

ex: item1, item2, item3... restItem

There is no index that can check if an item is the first or not.