### PR TITLE
Fix/ssr full display all invisibly

### DIFF
--- a/src/Overflow.tsx
+++ b/src/Overflow.tsx
@@ -302,7 +302,8 @@ function Overflow<ItemType = any>(
   // ================================ Render ================================
   const displayRest = restReady && !!omittedItems.length;
 
-  const isFullySSRAndFirstRender = fullySSR && containerWidth === null;
+  const isFullySSRResponsiveFirstRender =
+    fullySSR && shouldResponsive && containerWidth === null;
   const fullySSRFirstRenderStyle: React.CSSProperties = {
     maxWidth: 0,
     padding: 0,
@@ -311,7 +312,7 @@ function Overflow<ItemType = any>(
     overflowX: 'hidden',
   };
 
-  let suffixStyle: React.CSSProperties = isFullySSRAndFirstRender
+  let suffixStyle: React.CSSProperties = isFullySSRResponsiveFirstRender
     ? fullySSRFirstRenderStyle
     : {};
   if (suffixFixedStart !== null && shouldResponsive) {
@@ -327,7 +328,9 @@ function Overflow<ItemType = any>(
     responsive: shouldResponsive,
     component: itemComponent,
     invalidate,
-    style: isFullySSRAndFirstRender ? fullySSRFirstRenderStyle : undefined,
+    style: isFullySSRResponsiveFirstRender
+      ? fullySSRFirstRenderStyle
+      : undefined,
   };
 
   // >>>>> Choice render fun by `renderRawItem`
@@ -338,7 +341,7 @@ function Overflow<ItemType = any>(
         // in `ssr="full"` case, item's `display` will be set to `true` when either condition is met:
         // 1) at initial render; 2) its corresponding width is valid and pass the index check
         const shouldDisplay = fullySSR
-          ? isFullySSRAndFirstRender ||
+          ? isFullySSRResponsiveFirstRender ||
             (isIdxCheckPass && getItemWidth(index) > 0)
           : isIdxCheckPass;
         return (
@@ -363,7 +366,7 @@ function Overflow<ItemType = any>(
         // in `ssr="full"` case, item's `display` will be set to `true` when either condition is met:
         // 1) at initial render; 2) its corresponding width is valid and pass the index check
         const shouldDisplay = fullySSR
-          ? isFullySSRAndFirstRender ||
+          ? isFullySSRResponsiveFirstRender ||
             (isIdxCheckPass && getItemWidth(index) > 0)
           : isIdxCheckPass;
         return (

--- a/tests/__snapshots__/ssr.spec.tsx.snap
+++ b/tests/__snapshots__/ssr.spec.tsx.snap
@@ -6,20 +6,20 @@ exports[`Overflow.SSR basic 1`] = `
 >
   <div
     class="rc-overflow-item"
-    style="opacity:1;order:0"
+    style="opacity:1;order:0;max-width:0;padding:0;margin:0;border-width:0;overflow-x:hidden"
   >
     Label 0
   </div>
   <div
     class="rc-overflow-item"
-    style="opacity:1;order:1"
+    style="opacity:1;order:1;max-width:0;padding:0;margin:0;border-width:0;overflow-x:hidden"
   >
     Label 1
   </div>
   <div
     aria-hidden="true"
     class="rc-overflow-item rc-overflow-item-rest"
-    style="opacity:0;height:0;overflow-y:hidden;order:9007199254740991;pointer-events:none;position:absolute"
+    style="opacity:0;height:0;overflow-y:hidden;order:9007199254740991;pointer-events:none;position:absolute;max-width:0;padding:0;margin:0;border-width:0;overflow-x:hidden"
   >
     + 0 ...
   </div>


### PR DESCRIPTION
背景 & 复现方法:
close https://github.com/react-component/menu/pull/665

期许:
在overflow ssr="full" 模式下, 在首次渲染所有 items 内容时, SEO友好且页面不闪烁

代码改动简述:

逻辑部分
在 ssr="full", shouldResponsive 为true时,
让首次 render 时会绘制所有 items(display prop 为true, css 宽度为0);
message channel 执行更新 containerWidth itemWidths 等值(值虽有, 但都为0), 触发第二次 render

第2次 render 时所有 items(但display prop 为false, css 宽度则回归正常), 随后触发 layoutEffect, layoutEffect 更新 displayCount 为 data.length - 1, 同步开始第3次 render, render所有的 items 并绘制(此次display prop 为false, css 宽度正常)

随后等到 message channel 再次执行更新 itemWidths 等值, 触发第4次 render, 此时 itemWidths 赋有正确的值, 因此所有 items(display prop 为 true, css 宽度正常), 后触发 layoutEffect, 更新 displayCount 为正确的计算结果. 同步开始第5次render, 并正确绘制出应该可见的 items

更新 ssr 相关测试