### PR TITLE
feat:renderItem params add "index"

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   setupFiles: ['./tests/setup.js'],
   snapshotSerializers: [require.resolve('enzyme-to-json/serializer')],
+  transformIgnorePatterns: [
+    '/node_modules/(?!cheerio).+\\.js$',
+  ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,4 @@
 module.exports = {
   setupFiles: ['./tests/setup.js'],
   snapshotSerializers: [require.resolve('enzyme-to-json/serializer')],
-  transformIgnorePatterns: [
-    '/node_modules/(?!cheerio).+\\.js$',
-  ],
 };

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0"
   },
+  "overrides": {
+    "cheerio":"1.0.0-rc.12"
+  },
   "cnpm": {
     "mode": "npm"
   },

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -11,7 +11,7 @@ export interface ItemProps<ItemType> extends React.HTMLAttributes<any> {
   item?: ItemType;
   className?: string;
   style?: React.CSSProperties;
-  renderItem?: (item: ItemType) => React.ReactNode;
+  renderItem?: (item: ItemType, info: { index: number }) => React.ReactNode;
   responsive?: boolean;
   // https://github.com/ant-design/ant-design/issues/35475
   /**
@@ -66,7 +66,7 @@ function InternalItem<ItemType>(
 
   // ================================ Render ================================
   const childNode =
-    renderItem && item !== UNDEFINED ? renderItem(item) : children;
+    renderItem && item !== UNDEFINED ? renderItem(item, { index: order }) : children;
 
   let overflowStyle: React.CSSProperties | undefined;
   if (!invalidate) {

--- a/src/Overflow.tsx
+++ b/src/Overflow.tsx
@@ -24,7 +24,7 @@ export interface OverflowProps<ItemType> extends React.HTMLAttributes<any> {
   itemKey?: React.Key | ((item: ItemType) => React.Key);
   /** Used for `responsive`. It will limit render node to avoid perf issue */
   itemWidth?: number;
-  renderItem?: (item: ItemType) => React.ReactNode;
+  renderItem?: (item: ItemType, info: { index: number }) => React.ReactNode;
   /** @private Do not use in your production. Render raw node that need wrap Item by developer self */
   renderRawItem?: (item: ItemType, index: number) => React.ReactElement;
   maxCount?: number | typeof RESPONSIVE | typeof INVALIDATE;

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -51,6 +51,22 @@ describe('Overflow.Basic', () => {
     expect(wrapper.find('Item').text()).toEqual('Bamboo Is Light');
   });
 
+  it('renderItem params have "order"', () => {
+    const testData = getData(3);
+    const wrapper = mount(
+      <Overflow
+        data={testData}
+        renderItem={(item, info) => {
+          return `${item.label}-${info.index}-test`;
+        }}
+      />,
+    );
+    const renderedItems = wrapper.find('.rc-overflow-item');
+    expect(renderedItems).toHaveLength(testData.length);
+    renderedItems.forEach((node, index) => {
+      expect(node.text()).toBe(`${testData[index].label}-${index}-test`);
+    });
+  });
   describe('renderRest', () => {
     it('function', () => {
       const wrapper = mount(


### PR DESCRIPTION
修改背景：https://github.com/ant-design/ant-design/issues/31501
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了 `renderItem` 函数签名，现在支持传递额外的索引信息。

- **依赖更新**
	- 在 `package.json` 中为 "cheerio" 包指定了特定版本 "1.0.0-rc.12"。

- **测试**
	- 添加了新的测试用例，验证 `renderItem` 函数的新参数行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->