### PR TITLE
chore: migrate to @rc-component namespace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           key: lock-${{ github.sha }}
 
       - name: create package-lock.json
-        run: npm i --package-lock-only --ignore-scripts
+        run: npm i --package-lock-only --ignore-scripts --legacy-peer-deps
 
       - name: hack for singe file
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: install
         if: steps.node_modules_cache_id.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --legacy-peer-deps
   
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rc-overflow 🐾
+# @rc-component/overflow 🐾
 
 [![NPM version][npm-image]][npm-url]
 [![npm download][download-image]][download-url]
@@ -7,8 +7,8 @@
 [![bundle size][bundlephobia-image]][bundlephobia-url]
 [![dumi][dumi-image]][dumi-url]
 
-[npm-image]: http://img.shields.io/npm/v/rc-overflow.svg?style=flat-square
-[npm-url]: http://npmjs.org/package/rc-overflow
+[npm-image]: http://img.shields.io/npm/v/@rc-component/overflow.svg?style=flat-square
+[npm-url]: http://npmjs.org/package/@rc-component/overflow
 [github-actions-image]: https://github.com/react-component/overflow/workflows/CI/badge.svg
 [github-actions-url]: https://github.com/react-component/overflow/actions
 [codecov-image]: https://img.shields.io/codecov/c/github/react-component/overflow/master.svg?style=flat-square
@@ -17,10 +17,10 @@
 [david-image]: https://david-dm.org/react-component/overflow/status.svg?style=flat-square
 [david-dev-url]: https://david-dm.org/react-component/overflow?type=dev
 [david-dev-image]: https://david-dm.org/react-component/overflow/dev-status.svg?style=flat-square
-[download-image]: https://img.shields.io/npm/dm/rc-overflow.svg?style=flat-square
-[download-url]: https://npmjs.org/package/rc-overflow
-[bundlephobia-url]: https://bundlephobia.com/result?p=rc-overflow
-[bundlephobia-image]: https://badgen.net/bundlephobia/minzip/rc-overflow
+[download-image]: https://img.shields.io/npm/dm/@rc-component/overflow.svg?style=flat-square
+[download-url]: https://npmjs.org/package/@rc-component/overflow
+[bundlephobia-url]: https://bundlephobia.com/result?p=@rc-component/overflow
+[bundlephobia-image]: https://badgen.net/bundlephobia/minzip/@rc-component/overflow
 [dumi-url]: https://github.com/umijs/dumi
 [dumi-image]: https://img.shields.io/badge/docs%20by-dumi-blue?style=flat-square
 
@@ -32,7 +32,7 @@ https://overflow-react-component.vercel.app/
 
 ## Install
 
-[![rc-overflow](https://nodei.co/npm/rc-overflow.png)](https://npmjs.org/package/rc-overflow)
+[![@rc-component/overflow](https://nodei.co/npm/@rc-component/overflow.png)](https://npmjs.org/package/@rc-component/overflow)
 
 ## Usage
 
@@ -54,4 +54,4 @@ npm start
 
 ## License
 
-rc-overflow is released under the MIT license.
+@rc-component/overflow is released under the MIT license.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 hero:
-  title: rc-overflow
+  title: @rc-component/overflow
   description: React Overflow Component
 ---
 

--- a/examples/fill-width.tsx
+++ b/examples/fill-width.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import useLayoutEffect from "rc-util/lib/hooks/useLayoutEffect";
+import useLayoutEffect from "@rc-component/util/lib/hooks/useLayoutEffect";
 import Overflow from '../src';
 import '../assets/index.less';
 import './common.less';

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier": "prettier --write \"**/*.{js,jsx,tsx,ts,less,md,json}\"",
     "test": "rc-test",
     "test:coverage": "rc-test --coverage",
-    "prepublishOnly": "npm run compile && np --no-cleanup --yolo --no-publish",
+    "prepublishOnly": "npm run compile && rc-np",
     "lint": "eslint src/ --ext .tsx,.ts",
     "lint:tsc": "tsc -p tsconfig.json --noEmit",
     "now-build": "npm run docs:build"
@@ -50,7 +50,8 @@
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^1.0.0",
+    "@rc-component/father-plugin": "^2.0.0",
+    "@rc-component/np": "^1.0.4",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.0.0",
     "@types/enzyme": "^3.10.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rc-overflow",
-  "version": "1.4.1",
+  "name": "@rc-component/overflow",
+  "version": "1.0.0",
   "description": "Auto collapse box when overflow",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -45,15 +45,14 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.1",
-    "classnames": "^2.2.1",
-    "rc-resize-observer": "^1.0.0",
-    "rc-util": "^5.37.0"
+    "@rc-component/resize-observer": "^1.0.1",
+    "@rc-component/util": "^1.4.0",
+    "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^1.0.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.0.0",
-    "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^26.0.23",
     "@types/node": "^24.8.1",

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import classNames from 'classnames';
-import ResizeObserver from 'rc-resize-observer';
+import { clsx } from 'clsx';
+import ResizeObserver from '@rc-component/resize-observer';
 import type { ComponentType } from './RawItem';
 
 // Use shared variable to save bundle size
@@ -89,7 +89,7 @@ function InternalItem<ItemType>(
 
   let itemNode = (
     <Component
-      className={classNames(!invalidate && prefixCls, className)}
+      className={clsx(!invalidate && prefixCls, className)}
       style={{
         ...overflowStyle,
         ...style,

--- a/src/Overflow.tsx
+++ b/src/Overflow.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useState, useMemo, useCallback } from 'react';
-import classNames from 'classnames';
-import ResizeObserver from 'rc-resize-observer';
-import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
+import { clsx } from 'clsx';
+import ResizeObserver from '@rc-component/resize-observer';
+import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import Item from './Item';
 import useEffectState, { useBatcher } from './hooks/useEffectState';
 import type { ComponentType } from './RawItem';
@@ -394,7 +394,7 @@ function Overflow<ItemType = any>(
 
   const overflowNode = (
     <Component
-      className={classNames(!invalidate && prefixCls, className)}
+      className={clsx(!invalidate && prefixCls, className)}
       style={style}
       ref={ref}
       {...restProps}

--- a/src/RawItem.tsx
+++ b/src/RawItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import classNames from 'classnames';
+import { clsx } from 'clsx';
 import Item from './Item';
 import { OverflowContext } from './context';
 
@@ -31,7 +31,7 @@ const InternalRawItem = (props: RawItemProps, ref: React.Ref<any>) => {
     <OverflowContext.Provider value={null}>
       <Item
         ref={ref}
-        className={classNames(contextClassName, className)}
+        className={clsx(contextClassName, className)}
         {...restContext}
         {...restProps}
       />

--- a/src/hooks/channelUpdate.ts
+++ b/src/hooks/channelUpdate.ts
@@ -1,4 +1,4 @@
-import raf from 'rc-util/lib/raf';
+import raf from '@rc-component/util/lib/raf';
 
 export default function channelUpdate(callback: VoidFunction) {
   if (typeof MessageChannel === 'undefined') {

--- a/src/hooks/useEffectState.tsx
+++ b/src/hooks/useEffectState.tsx
@@ -1,4 +1,4 @@
-import useEvent from 'rc-util/lib/hooks/useEvent';
+import useEvent from '@rc-component/util/lib/hooks/useEvent';
 import * as React from 'react';
 import { unstable_batchedUpdates } from 'react-dom';
 import channelUpdate from './channelUpdate';

--- a/tests/github.spec.tsx
+++ b/tests/github.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, act } from '@testing-library/react';
-import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 import Overflow from '../src';
 
-import { _rs as onResize } from 'rc-resize-observer/lib/utils/observerUtil';
+import { _rs as onResize } from '@rc-component/resize-observer/lib/utils/observerUtil';
 
 interface ItemType {
   label: React.ReactNode;


### PR DESCRIPTION
迁移到 @rc-component 空间

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **杂务**
  * 包名由 `rc-overflow` 改为 `@rc-component/overflow`，版本重置为 1.0.0，发布脚本与依赖项替换（clsx、@rc-component/resize-observer、@rc-component/util 等）。
  * CI 安装命令添加 --legacy-peer-deps。

* **文档**
  * README 与站点标题、徽章与安装说明更新为新包名。

* **重构**
  * 若干导入路径与类名拼接工具（classnames → clsx）替换，行为不变。

* **测试**
  * 测试依赖导入路径同步更新，测试逻辑无改动。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->