### PR TITLE
fix: use logical suffix offset for rtl overflow

### DIFF
--- a/src/Overflow.tsx
+++ b/src/Overflow.tsx
@@ -318,8 +318,8 @@ function Overflow<ItemType = any>(
   if (suffixFixedStart !== null && shouldResponsive) {
     suffixStyle = {
       position: 'absolute',
-      left: suffixFixedStart,
       top: 0,
+      insetInlineStart: suffixFixedStart,
     };
   }
 

--- a/tests/responsive.spec.tsx
+++ b/tests/responsive.spec.tsx
@@ -186,7 +186,11 @@ describe('Overflow.Responsive', () => {
       wrapper.initSize(100, 20);
 
       expect(wrapper.findSuffix().props().style).toEqual(
-        expect.objectContaining({ position: 'absolute', top: 0, left: 80 }),
+        expect.objectContaining({
+          position: 'absolute',
+          top: 0,
+          insetInlineStart: 80,
+        }),
       );
     });
 


### PR DESCRIPTION
## Summary
- replace the pinned responsive suffix `left` offset with `inset-inline-start`
- let logical positioning follow the container direction automatically in both LTR and RTL

Closes ant-design/ant-design#57680


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* 优化了响应式布局中后缀元素的定位样式，增强兼容性表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->